### PR TITLE
Moved phpunit to require-dev

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -42,10 +42,10 @@
     "name": "zetacomponents/url",
     "type": "library",
     "require": {
-        "zetacomponents/base": "~1.8",
-        "phpunit/phpunit": "^7.5"
+        "zetacomponents/base": "~1.8"
     },
     "require-dev": {
-        "zetacomponents/unit-test": "*"
+        "zetacomponents/unit-test": "*",
+        "phpunit/phpunit": "^7.5"
     }
 }


### PR DESCRIPTION
There's not much point having the unit tests as a requirement.

1. It's a dev requirement and isn't required for production environments
2. Different upstream dependants may require different phpunit versions and having phpunit as a core dependency will break installs